### PR TITLE
Fix bug when setting value of Auto Size mode

### DIFF
--- a/samples/ComposeBoxTextOptions_ScriptUISample.jsx
+++ b/samples/ComposeBoxTextOptions_ScriptUISample.jsx
@@ -337,7 +337,7 @@
 
                 dropdown_autosize.selection = getIndexOfArrayItem(
                     dropdown_autosize_array,
-                    autoFitPolicyOptionsMapper.enumToName(currentBoxValues.boxAutoFitPolicy)
+                    autoFitPolicyOptionsMapper.enumToName(newBoxValues.boxAutoFitPolicy)
                 );
             } else {
                 label_autofitpolicy.enabled = dropdown_autosize.enabled = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes a bug in the ComposeBoxTextOptions_ScriptUISample.jsx when setting the Auto Size value for Box text.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
